### PR TITLE
fixed: problem with naming of field isRequired

### DIFF
--- a/src/main/java/com/example/pj_webshop/entities/models/dto/ProductOptionGroupDTO.java
+++ b/src/main/java/com/example/pj_webshop/entities/models/dto/ProductOptionGroupDTO.java
@@ -1,5 +1,6 @@
 package com.example.pj_webshop.entities.models.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
@@ -9,6 +10,7 @@ public class ProductOptionGroupDTO {
     private int productOptionGroupId;
     private int productPropertiesId;
     private String name;
+    @JsonProperty("isRequired")
     private boolean isRequired;
     private String groupModificationMode;
     private String availableOptionsState;

--- a/src/main/java/com/example/pj_webshop/entities/models/products/ProductOptionGroup.java
+++ b/src/main/java/com/example/pj_webshop/entities/models/products/ProductOptionGroup.java
@@ -1,6 +1,7 @@
 package com.example.pj_webshop.entities.models.products;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,6 +27,7 @@ public class ProductOptionGroup {
     private String name;
 
     @Column(name = "is_required")
+    @JsonProperty("isRequired")
     private boolean isRequired;
 
     @Column(name = "group_modification_mode")


### PR DESCRIPTION
fixed: problem with naming of field isRequired in ProductOptionGroup. Now 'isRequired' is used both in object and dto